### PR TITLE
LB-1112: Add 'Profile' link to drop down

### DIFF
--- a/listenbrainz/webserver/templates/navbar.html
+++ b/listenbrainz/webserver/templates/navbar.html
@@ -71,6 +71,7 @@
               {{ current_user.musicbrainz_id }} <span class="caret"></span>
             </a>
             <ul class="dropdown-menu" role="menu">
+              <li><a href="{{ url_for('user.profile', user_name=current_user.musicbrainz_id) }}">Profile</a></li>
               <li><a href="{{ url_for('profile.info') }}">Settings</a></li>
               <li><a href="{{ url_for('user.playlists', user_name=current_user.musicbrainz_id) }}">Playlists</a></li>
               <li><a href="{{ url_for('recommendations_cf_recording.info', user_name=current_user.musicbrainz_id) }}">Tracks you might like</a></li>


### PR DESCRIPTION
Adding a 'Profile' dropdown under the user menu to match all other MetaBrainz sites/expected behaviours (MB, BB)
(yes, this is doubling up with the 'Home' button. But gives us future flexibility there)

https://tickets.metabrainz.org/browse/LB-1112?